### PR TITLE
Remove PDF and tika

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-  - 2.2.8
-  - 2.3.5
-  - 2.4.2
+  - 2.6.2
+  - 2.5.4
+  - 2.4.5
 before_install:
   - gem update bundler

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Slaw [![Build Status](https://travis-ci.org/longhotsummer/slaw.svg)](http://travis-ci.org/longhotsummer/slaw)
 
-Slaw is a lightweight library for generating Akoma Ntoso 2.0 Act XML from plain text and PDF documents.
+Slaw is a lightweight library for generating Akoma Ntoso 2.0 Act XML from plain text documents.
 It is used to power [Indigo](https://github.com/OpenUpSA/indigo) and uses grammars developed for the legal
 traditions in these countries:
 
@@ -30,19 +30,9 @@ Or install it with:
 
     $ gem install slaw
 
-To run PDF extraction you will also need [poppler's pdftotext](https://poppler.freedesktop.org/).
-If you're on a Mac, you can use:
-
-    $ brew install poppler
-
-You may also need Ghostscript to remove password protection from PDF files. This is
-installed by default on most systems (including Mac). On Ubuntu you can use:
-
-    $ sudo apt-get install ghostscript
-
 The simplest way to use Slaw is via the commandline:
 
-    $ slaw parse myfile.pdf --grammar za
+    $ slaw parse myfile.text --grammar za
 
 ## Overview
 
@@ -50,8 +40,8 @@ Slaw generates Acts in the [Akoma Ntoso](http://www.akomantoso.org) 2.0 XML
 standard for legislative documents. It first parses plain text using a grammar
 and then generates XML from the resulting syntax tree.
 
-Most by-laws in South Africa are available as PDF documents. Slaw therefore has support
-for extracting and cleaning up text from PDFs before parsing it. Extracting text from
+Most by-laws in South Africa are available as PDF documents. You will therefore
+need to extract the text from the PDF first, using a tool like pdftotext.
 PDFs can product oddities (such as oddly wrapped lines) and Slaw has a number of
 rules-of-thumb for correcting these. These rules are based on South African
 by-laws and may not be suitable for all regions.
@@ -85,6 +75,10 @@ and parser.
 8. Create a new Pull Request
 
 ## Changelog
+
+### 2.0.0 (?)
+
+* Remove support for PDFs. Do text extraction from PDFs outside of this library.
 
 ### 1.0.4 (5 February 2019)
 

--- a/bin/slaw
+++ b/bin/slaw
@@ -4,8 +4,6 @@ require 'thor'
 require 'slaw'
 
 class SlawCLI < Thor
-  # TODO: support different grammars and locales
-
   # Exit with non-zero exit code on failure.
   # See https://github.com/erikhuda/thor/issues/244
   def self.exit_on_failure?
@@ -15,29 +13,19 @@ class SlawCLI < Thor
   class_option :verbose, type: :boolean, desc: "Display log output on stderr"
 
   desc "parse FILE", "Parse FILE into Akoma Ntoso XML"
-  option :input, enum: ['text', 'pdf'], desc: "Type of input if it can't be determined automatically"
-  option :pdftotext, desc: "Location of the pdftotext binary if not in PATH"
+  option :input, enum: ['text', 'html'], desc: "Type of input if it can't be determined automatically"
   option :fragment, type: :string, desc: "Akoma Ntoso element name that the imported text represents. Support depends on the grammar."
   option :id_prefix, type: :string, desc: "Prefix to be used when generating ID elements when parsing a fragment."
   option :section_number_position, enum: ['before-title', 'after-title', 'guess'], desc: "Where do section titles come in relation to the section number? Default: before-title"
-  option :crop, type: :string, desc: "Crop box for PDF files, as 'left,top,width,height'."
   option :grammar, type: :string, desc: "Grammar name (usually a two-letter country code). Default is za."
   def parse(name)
     logging
 
-    Slaw::Extract::Extractor.pdftotext_path = options[:pdftotext] if options[:pdftotext]
     extractor = Slaw::Extract::Extractor.new
 
-    if options[:crop]
-      extractor.cropbox = options[:crop].split(',').map(&:to_i)
-      if extractor.cropbox.length != 4
-        raise Thor::Error.new("--crop requires four comma-separated integers")
-      end
-    end
-
     case options[:input]
-    when 'pdf'
-      text = extractor.extract_from_pdf(name)
+    when 'html'
+      text = extractor.extract_from_html(name)
     when 'text'
       text = extractor.extract_from_text(name)
     else

--- a/lib/slaw/extract/extractor.rb
+++ b/lib/slaw/extract/extractor.rb
@@ -1,23 +1,11 @@
-require 'open3'
-require 'tempfile'
 require 'mimemagic'
 
 module Slaw
   module Extract
 
-    # Routines for extracting and cleaning up context from other formats, such as PDF.
-    #
-    # You may need to set the location of the `pdftotext` binary. 
-    #
-    # On Mac OS X, use `brew install xpdf` or download from http://www.foolabs.com/xpdf/download.html
-    #
-    # On Heroku, you'll need to do some hoop jumping, see http://theprogrammingbutler.com/blog/archives/2011/07/28/running-pdftotext-on-heroku/
+    # Routines for extracting and cleaning up context from other formats, such as HTML.
     class Extractor
       include Slaw::Logging
-
-      @@pdftotext_path = "pdftotext"
-
-      attr_accessor :cropbox
 
       # Extract text from a file.
       #
@@ -28,61 +16,13 @@ module Slaw
         mimetype = get_mimetype(filename)
 
         case mimetype && mimetype.type
-        when 'application/pdf'
-          extract_from_pdf(filename)
-        when 'text/html', nil
+        when 'text/html'
           extract_from_html(filename)
         when 'text/plain', nil
           extract_from_text(filename)
         else
-          text = extract_via_tika(filename)
-          if text.empty? or text.nil?
-            raise ArgumentError.new("Unsupported file type #{mimetype || 'unknown'}")
-          end
-          text
+          raise ArgumentError.new("Unsupported file type #{mimetype || 'unknown'}")
         end
-      end
-
-      # Extract text from a PDF
-      #
-      # @param filename [String] filename to extract from
-      #
-      # @return [String] extracted text
-      def extract_from_pdf(filename)
-        retried = false
-
-        while true
-          cmd = pdf_to_text_cmd(filename)
-          logger.info("Executing: #{cmd}")
-          stdout, status = Open3.capture2(*cmd)
-
-          case status.exitstatus
-          when 0
-            return stdout
-          when 3
-            return nil if retried
-            retried = true
-            self.remove_pdf_password(filename)
-          else
-            return nil
-          end
-        end
-      end
-
-      # Build a command for the external PDF-to-text utility.
-      #
-      # @param filename [String] the pdf file
-      #
-      # @return [Array<String>] command and params to execute
-      def pdf_to_text_cmd(filename)
-        cmd = [Extractor.pdftotext_path, "-enc", "UTF-8", "-nopgbrk"]
-
-        if @cropbox
-          # left, top, width, height
-          cmd += "-x -y -W -H".split.zip(@cropbox.map(&:to_s)).flatten
-        end
-
-        cmd + [filename, "-"]
       end
 
       def extract_from_text(filename)
@@ -91,21 +31,6 @@ module Slaw
 
       def extract_from_html(filename)
         html_to_text(File.read(filename))
-      end
-
-      # Extract text from +filename+ by sending it to apache tika
-      # http://tika.apache.org/
-      def extract_via_tika(filename)
-        # the Yomu gem falls over when trying to write large amounts of data
-        # the JVM stdin, so we manually call java ourselves, relying on yomu
-        # to supply the gem
-        require 'slaw/extract/yomu_patch'
-        logger.info("Using Tika to get text from #{filename}. You need a JVM installed for this.")
-
-        html = Yomu.text_from_file(filename)
-        logger.info("Tika returned #{html.length} bytes")
-        # transform html into text
-        html_to_text(html)
       end
 
       def html_to_text(html)
@@ -117,33 +42,9 @@ module Slaw
         text.sub(/^<\?xml [^>]*>/, '')
       end
 
-      def remove_pdf_password(filename)
-        file = Tempfile.new('steno')
-        begin
-          logger.info("Trying to remove password from #{filename}")
-          cmd = "gs -q -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile=#{file.path} -c .setpdfwrite -f #{filename}".split(" ")
-          logger.info("Executing: #{cmd}")
-          Open3.capture2(*cmd)
-          FileUtils.move(file.path, filename)
-        ensure
-          file.close
-          file.unlink
-        end
-      end
-
       def get_mimetype(filename)
         File.open(filename) { |f| MimeMagic.by_magic(f) } \
           || MimeMagic.by_path(filename)
-      end
-
-      # Get location of the pdftotext executable for all instances.
-      def self.pdftotext_path
-        @@pdftotext_path
-      end
-
-      # Set location of the pdftotext executable for all instances.
-      def self.pdftotext_path=(val)
-        @@pdftotext_path = val
       end
     end
   end

--- a/lib/slaw/extract/yomu_patch.rb
+++ b/lib/slaw/extract/yomu_patch.rb
@@ -1,9 +1,0 @@
-require 'yomu'
-
-class Yomu
-  def self.text_from_file(filename)
-    IO.popen("#{java} -Djava.awt.headless=true -jar #{Yomu::JARPATH} --html '#{filename}'", 'r') do |io|
-      io.read
-    end
-  end
-end

--- a/lib/slaw/version.rb
+++ b/lib/slaw/version.rb
@@ -1,3 +1,3 @@
 module Slaw
-  VERSION = "1.0.4"
+  VERSION = "2.0.0"
 end

--- a/slaw.gemspec
+++ b/slaw.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake", "~> 10.3.1"
   spec.add_development_dependency "rspec", "~> 2.14.1"
 
@@ -27,8 +26,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "log4r", "~> 1.1.10"
   spec.add_runtime_dependency "thor", "~> 0.19.1"
   spec.add_runtime_dependency "mimemagic", "~> 0.2.1"
-  spec.add_runtime_dependency 'yomu', '~> 0.2.2'
-  # anchor twitter-text to avoid bug in 1.14.3
-  # https://github.com/twitter/twitter-text/issues/162
-  spec.add_runtime_dependency 'twitter-text', '~> 1.12.0'
 end


### PR DESCRIPTION
This simplifies slaw greatly. Extract text from PDFs and other documents before providing it to Slaw.

Slaw only supports text and html now.