### PR TITLE
Improvements from slaw-ke

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,13 @@ You can create your own grammar by creating a gem that provides these files and 
 
 ## Changelog
 
-### 2.3.0 (?)
+### 3.0.0 (?)
 
 * Inline bold and italics
+* Support for CROSSHEADING elements using an empty hcontainer until we support AKN 3.0
+* Support for LONGTITLE in PREFACE
 * Remarks and references support nested inline elements
+* BREAKING: `clauses` rule renamed to `inline_elements` so as not to clash with real AKN clauses
 
 ### 2.2.0 (18 March 2019)
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ You can create your own grammar by creating a gem that provides these files and 
 
 ## Changelog
 
+### 2.3.0 (?)
+
+* Inline bold and italics
+* Remarks and references support nested inline elements
+
 ### 2.2.0 (18 March 2019)
 
 * Schedules use hcontainer, not article

--- a/lib/slaw/grammars/inlines.treetop
+++ b/lib/slaw/grammars/inlines.treetop
@@ -26,7 +26,7 @@ module Slaw
       end
 
       rule remark
-        '[[' content:(ref / (!']]' .))+ ']]'
+        '[[' content:(!']]' inline_item)+ ']]'
         <Remark>
       end
 

--- a/lib/slaw/grammars/inlines.treetop
+++ b/lib/slaw/grammars/inlines.treetop
@@ -10,14 +10,14 @@ module Slaw
       # inline content
 
       rule inline_statement
-        space? '\\'? clauses eol
+        space? '\\'? inline_items eol
         <NakedStatement>
       end
 
       # one or more words, allowing inline elements
       # TODO: this is badly named, a better name would be inline_items
-      rule clauses
-        inline_item+ <Clauses>
+      rule inline_items
+        inline_item+ <InlineItems>
       end
 
       rule inline_item

--- a/lib/slaw/grammars/inlines.treetop
+++ b/lib/slaw/grammars/inlines.treetop
@@ -15,9 +15,14 @@ module Slaw
       end
 
       # one or more words, allowing inline elements
+      # TODO: this is badly named, a better name would be inline_items
       rule clauses
-        (remark / image / ref / [^\n])+
-        <Clauses>
+        inline_item+ <Clauses>
+      end
+
+      rule inline_item
+        remark / image / ref / bold / italics / [^\n]
+        <InlineItem>
       end
 
       rule remark
@@ -34,12 +39,25 @@ module Slaw
         <Image>
       end
 
+      rule bold
+        # **foo**
+        '**' content:(!'**' inline_item)+ '**'
+        <Bold>
+      end
+
+      rule italics
+        # //foo//
+        '//' content:(!'//' inline_item)+ '//'
+        <Italics>
+      end
+
       rule ref
         # links like markdown
         # eg. [link text](link url)
-        '[' content:(!'](' [^\n])+ '](' href:([^)\n]+) ')'
+        '[' content:(!'](' inline_item)+ '](' href:([^)\n]+) ')'
         <Ref>
       end
+
     end
   end
 end

--- a/lib/slaw/grammars/inlines_nodes.rb
+++ b/lib/slaw/grammars/inlines_nodes.rb
@@ -3,15 +3,15 @@ module Slaw
     module Inlines
       class NakedStatement < Treetop::Runtime::SyntaxNode
         def to_xml(b, idprefix, i=0)
-          b.p { |b| clauses.to_xml(b, idprefix) } if clauses
+          b.p { |b| inline_items.to_xml(b, idprefix) } if inline_items
         end
 
         def content
-          clauses
+          inline_items
         end
       end
 
-      class Clauses < Treetop::Runtime::SyntaxNode
+      class InlineItems < Treetop::Runtime::SyntaxNode
         def to_xml(b, idprefix=nil)
           for e in elements
             e.to_xml(b, idprefix)

--- a/lib/slaw/grammars/inlines_nodes.rb
+++ b/lib/slaw/grammars/inlines_nodes.rb
@@ -24,11 +24,7 @@ module Slaw
           b.remark(status: 'editorial') do |b|
             b.text('[')
             for e in content.elements
-              if e.respond_to? :to_xml
-                e.to_xml(b, idprefix)
-              else
-                b.text(e.text_value)
-              end
+              e.inline_item.to_xml(b, idprefix)
             end
             b.text(']')
           end

--- a/lib/slaw/grammars/inlines_nodes.rb
+++ b/lib/slaw/grammars/inlines_nodes.rb
@@ -14,11 +14,7 @@ module Slaw
       class Clauses < Treetop::Runtime::SyntaxNode
         def to_xml(b, idprefix=nil)
           for e in elements
-            if e.respond_to? :to_xml
-              e.to_xml(b, idprefix)
-            else
-              b.text(e.text_value)
-            end
+            e.to_xml(b, idprefix)
           end
         end
       end
@@ -47,9 +43,39 @@ module Slaw
         end
       end
 
+      class InlineItem < Treetop::Runtime::SyntaxNode
+        def to_xml(b, idprefix)
+          b.text(text_value)
+        end
+      end
+
       class Ref < Treetop::Runtime::SyntaxNode
         def to_xml(b, idprefix)
-          b.ref(content.text_value, href: href.text_value)
+          b.ref(href: href.text_value) { |b|
+            for e in content.elements
+              e.inline_item.to_xml(b, idprefix)
+            end
+          }
+        end
+      end
+
+      class Bold < Treetop::Runtime::SyntaxNode
+        def to_xml(b, idprefix)
+          b.b { |b|
+            for e in content.elements
+              e.inline_item.to_xml(b, idprefix)
+            end
+          }
+        end
+      end
+
+      class Italics < Treetop::Runtime::SyntaxNode
+        def to_xml(b, idprefix)
+          b.i { |b|
+            for e in content.elements
+              e.inline_item.to_xml(b, idprefix)
+            end
+          }
         end
       end
 

--- a/lib/slaw/grammars/schedules.treetop
+++ b/lib/slaw/grammars/schedules.treetop
@@ -20,8 +20,8 @@ module Slaw
       end
 
       rule schedule_title
-        space? schedule_title_prefix space? "\""? num:alphanums? "\""? [ \t:.-]* title:clauses?
-        subheading:(newline space? clauses)?
+        space? schedule_title_prefix space? "\""? num:alphanums? "\""? [ \t:.-]* title:inline_items?
+        subheading:(newline space? inline_items)?
         eol
       end
 

--- a/lib/slaw/grammars/schedules_nodes.rb
+++ b/lib/slaw/grammars/schedules_nodes.rb
@@ -45,7 +45,7 @@ module Slaw
 
         def subheading
           if not schedule_title.subheading.text_value.blank?
-            schedule_title.subheading.clauses
+            schedule_title.subheading.inline_items
           else
             nil
           end
@@ -113,7 +113,7 @@ module Slaw
 
       class ScheduleStatement < Treetop::Runtime::SyntaxNode
         def to_xml(b, idprefix)
-          b.p { |b| clauses.to_xml(b, idprefix) } if clauses
+          b.p { |b| inline_items.to_xml(b, idprefix) } if inline_items
         end
       end
     end

--- a/lib/slaw/grammars/schedules_nodes.rb
+++ b/lib/slaw/grammars/schedules_nodes.rb
@@ -27,7 +27,7 @@ module Slaw
         def alias
           if not schedule_title.title.text_value.blank?
             # plain-text elements only
-            schedule_title.title.elements.select { |x| !x.respond_to? :to_xml }.map { |x| x.text_value }.join('').strip
+            schedule_title.title.elements.select { |x| x.instance_of? ::Slaw::Grammars::Inlines::InlineItem }.map { |x| x.text_value }.join('').strip
           elsif num
             "Schedule #{num}"
           else

--- a/lib/slaw/grammars/tables.treetop
+++ b/lib/slaw/grammars/tables.treetop
@@ -38,7 +38,7 @@ module Slaw
       end
 
       rule table_line
-        clauses:clauses? eol
+        inline_items:inline_items? eol
         <TableLine>
       end
 

--- a/lib/slaw/grammars/tables_nodes.rb
+++ b/lib/slaw/grammars/tables_nodes.rb
@@ -59,12 +59,12 @@ module Slaw
       class TableLine < Treetop::Runtime::SyntaxNode
         # line of table content
         def to_xml(b, i, tail)
-          clauses.to_xml(b) unless clauses.empty?
+          inline_items.to_xml(b) unless inline_items.empty?
 
           # add trailing newlines.
           #   for the first line, eat whitespace at the start
           #   for the last line, eat whitespace at the end
-          if not tail and (i > 0 or not clauses.empty?)
+          if not tail and (i > 0 or not inline_items.empty?)
             eol.text_value.count("\n").times { b.eol }
           end
         end

--- a/lib/slaw/grammars/za/act.treetop
+++ b/lib/slaw/grammars/za/act.treetop
@@ -130,6 +130,10 @@ module Slaw
         # blocks of content inside containers
 
         rule block_paragraphs
+          crossheading / block_elements
+        end
+
+        rule block_elements
           block_element+ <BlockParagraph>
         end
 
@@ -164,13 +168,18 @@ module Slaw
         # and is ignored. This allows escaping of section headings, etc.
 
         rule naked_statement
-          space? !(chapter_heading / part_heading / section_title / schedule_title / subsection_prefix) '\\'? clauses eol
+          space? !(chapter_heading / part_heading / section_title / schedule_title / subsection_prefix / crossheading) '\\'? clauses eol
           <NakedStatement>
         end
 
         rule pre_body_statement
           space? !(chapter_heading / part_heading / section_title / schedule_title) '\\'? clauses eol
           <NakedStatement>
+        end
+
+        rule crossheading
+          'CROSSHEADING ' clauses:clauses eol
+          <Crossheading>
         end
 
         ##########

--- a/lib/slaw/grammars/za/act.treetop
+++ b/lib/slaw/grammars/za/act.treetop
@@ -153,7 +153,7 @@ module Slaw
 
         rule blocklist_item
           # TODO: this whitespace should probably be space, to allow empty blocklist items followed by plain text
-          space? blocklist_item_prefix whitespace item_content:(!blocklist_item_prefix clauses:clauses? eol)? eol?
+          space? blocklist_item_prefix whitespace item_content:(!blocklist_item_prefix inline_items:inline_items? eol)? eol?
           <BlocklistItem>
         end
 
@@ -168,28 +168,28 @@ module Slaw
         # and is ignored. This allows escaping of section headings, etc.
 
         rule naked_statement
-          space? !(chapter_heading / part_heading / section_title / schedule_title / subsection_prefix / crossheading) '\\'? clauses eol
+          space? !(chapter_heading / part_heading / section_title / schedule_title / subsection_prefix / crossheading) '\\'? inline_items eol
           <NakedStatement>
         end
 
         rule preface_statement
           space? !(chapter_heading / part_heading / section_title / schedule_title)
-          content:(longtitle / ('\\'? clauses:clauses eol))
+          content:(longtitle / ('\\'? inline_items:inline_items eol))
           <PrefaceStatement>
         end
 
         rule preamble_statement
-          space? !(chapter_heading / part_heading / section_title / schedule_title) '\\'? clauses eol
+          space? !(chapter_heading / part_heading / section_title / schedule_title) '\\'? inline_items eol
           <NakedStatement>
         end
 
         rule crossheading
-          'CROSSHEADING ' clauses:clauses eol
+          'CROSSHEADING ' inline_items:inline_items eol
           <Crossheading>
         end
 
         rule longtitle
-          'LONGTITLE ' clauses:clauses eol
+          'LONGTITLE ' inline_items:inline_items eol
           <LongTitle>
         end
 

--- a/lib/slaw/grammars/za/act.treetop
+++ b/lib/slaw/grammars/za/act.treetop
@@ -28,12 +28,12 @@ module Slaw
         rule preface
           !'PREAMBLE'
           ('PREFACE'i space? eol)?
-          statements:(!'PREAMBLE' pre_body_statement)* <Preface>
+          statements:(!'PREAMBLE' preface_statement)* <Preface>
         end
 
         rule preamble
           'PREAMBLE'i space? eol
-          statements:pre_body_statement* <Preamble>
+          statements:preamble_statement* <Preamble>
         end
 
         rule body
@@ -172,7 +172,13 @@ module Slaw
           <NakedStatement>
         end
 
-        rule pre_body_statement
+        rule preface_statement
+          space? !(chapter_heading / part_heading / section_title / schedule_title)
+          content:(longtitle / ('\\'? clauses:clauses eol))
+          <PrefaceStatement>
+        end
+
+        rule preamble_statement
           space? !(chapter_heading / part_heading / section_title / schedule_title) '\\'? clauses eol
           <NakedStatement>
         end
@@ -180,6 +186,11 @@ module Slaw
         rule crossheading
           'CROSSHEADING ' clauses:clauses eol
           <Crossheading>
+        end
+
+        rule longtitle
+          'LONGTITLE ' clauses:clauses eol
+          <LongTitle>
         end
 
         ##########

--- a/lib/slaw/grammars/za/act_nodes.rb
+++ b/lib/slaw/grammars/za/act_nodes.rb
@@ -91,6 +91,32 @@ module Slaw
           end
         end
 
+        class PrefaceStatement < Treetop::Runtime::SyntaxNode
+          def to_xml(b, idprefix, i=0)
+            if longtitle
+              longtitle.to_xml(b, idprefix)
+            else
+              b.p { |b| clauses.to_xml(b, idprefix) }
+            end
+          end
+
+          def longtitle
+            self.content if self.content.is_a? LongTitle
+          end
+
+          def clauses
+            content.clauses if content.respond_to? :clauses
+          end
+        end
+
+        class LongTitle < Treetop::Runtime::SyntaxNode
+          def to_xml(b, idprefix, i=0)
+            b.longTitle { |b|
+              b.p { |b| clauses.to_xml(b, idprefix) }
+            }
+          end
+        end
+
         class Preamble < Treetop::Runtime::SyntaxNode
           def to_xml(b, *args)
             if text_value != ""

--- a/lib/slaw/grammars/za/act_nodes.rb
+++ b/lib/slaw/grammars/za/act_nodes.rb
@@ -301,6 +301,25 @@ module Slaw
           end
         end
 
+        class Crossheading < Treetop::Runtime::SyntaxNode
+          @@counters = {}
+
+          def self.counters
+            @@counters
+          end
+
+          def to_xml(b, idprefix, i=0)
+            @@counters[idprefix] ||= -1
+            @@counters[idprefix] += 1
+            id = "#{idprefix}crossheading-#{@@counters[idprefix]}"
+
+            b.hcontainer(id: id, name: 'crossheading') { |b|
+              b.heading { |b|
+                clauses.to_xml(b, idprefix)
+              }
+            }
+          end
+        end
       end
     end
   end

--- a/lib/slaw/grammars/za/act_nodes.rb
+++ b/lib/slaw/grammars/za/act_nodes.rb
@@ -96,7 +96,7 @@ module Slaw
             if longtitle
               longtitle.to_xml(b, idprefix)
             else
-              b.p { |b| clauses.to_xml(b, idprefix) }
+              b.p { |b| inline_items.to_xml(b, idprefix) }
             end
           end
 
@@ -104,15 +104,15 @@ module Slaw
             self.content if self.content.is_a? LongTitle
           end
 
-          def clauses
-            content.clauses if content.respond_to? :clauses
+          def inline_items
+            content.inline_items if content.respond_to? :inline_items
           end
         end
 
         class LongTitle < Treetop::Runtime::SyntaxNode
           def to_xml(b, idprefix, i=0)
             b.longTitle { |b|
-              b.p { |b| clauses.to_xml(b, idprefix) }
+              b.p { |b| inline_items.to_xml(b, idprefix) }
             }
           end
         end
@@ -321,7 +321,7 @@ module Slaw
             b.item(id: idprefix + num.gsub(/[()]/, '')) { |b|
               b.num(num)
               b.p { |b|
-                item_content.clauses.to_xml(b, idprefix) if respond_to? :item_content and item_content.respond_to? :clauses
+                item_content.inline_items.to_xml(b, idprefix) if respond_to? :item_content and item_content.respond_to? :inline_items
               }
             }
           end
@@ -341,7 +341,7 @@ module Slaw
 
             b.hcontainer(id: id, name: 'crossheading') { |b|
               b.heading { |b|
-                clauses.to_xml(b, idprefix)
+                inline_items.to_xml(b, idprefix)
               }
             }
           end

--- a/lib/slaw/grammars/za/act_text.xsl
+++ b/lib/slaw/grammars/za/act_text.xsl
@@ -88,6 +88,20 @@
     <xsl:apply-templates select="./*[not(self::a:num) and not(self::a:heading)]" />
   </xsl:template>
 
+  <!-- crossheadings -->
+  <xsl:template match="a:hcontainer[@name='crossheading']">
+    <xsl:text>CROSSHEADING </xsl:text>
+    <xsl:apply-templates select="a:heading" />
+    <xsl:text>&#10;&#10;</xsl:text>
+  </xsl:template>
+
+  <!-- longtitle -->
+  <xsl:template match="a:longTitle">
+    <xsl:text>LONGTITLE </xsl:text>
+    <xsl:apply-templates />
+    <xsl:text>&#10;&#10;</xsl:text>
+  </xsl:template>
+
   <!-- p tags must end with a blank line -->
   <xsl:template match="a:p">
     <xsl:apply-templates/>
@@ -237,6 +251,18 @@
     <xsl:text>](</xsl:text>
     <xsl:value-of select="@src" />
     <xsl:text>)</xsl:text>
+  </xsl:template>
+
+  <xsl:template match="a:i">
+    <xsl:text>//</xsl:text>
+    <xsl:apply-templates />
+    <xsl:text>//</xsl:text>
+  </xsl:template>
+
+  <xsl:template match="a:b">
+    <xsl:text>**</xsl:text>
+    <xsl:apply-templates />
+    <xsl:text>**</xsl:text>
   </xsl:template>
 
   <xsl:template match="a:eol">

--- a/lib/slaw/version.rb
+++ b/lib/slaw/version.rb
@@ -1,3 +1,3 @@
 module Slaw
-  VERSION = "2.2.0"
+  VERSION = "2.3.0"
 end

--- a/lib/slaw/version.rb
+++ b/lib/slaw/version.rb
@@ -1,3 +1,3 @@
 module Slaw
-  VERSION = "2.3.0"
+  VERSION = "3.0.0"
 end

--- a/spec/za/act_block_spec.rb
+++ b/spec/za/act_block_spec.rb
@@ -1991,4 +1991,74 @@ EOS
 </hcontainer>'
     end
   end
+
+  #-------------------------------------------------------------------------------
+  # longTitle
+
+  context 'longtitle' do
+    it 'should handle a basic longtitle' do
+      node = parse :longtitle, "LONGTITLE something [[remark]] [link](/foo/bar)\n"
+      to_xml(node, '').should == '<longTitle>
+  <p>something <remark status="editorial">[remark]</remark> <ref href="/foo/bar">link</ref></p>
+</longTitle>'
+    end
+
+    it 'should handle a longtitle in a preface' do
+      node = parse :act, <<EOS
+PREFACE
+
+Blah blah
+
+LONGTITLE a long title
+
+\\LONGTITLE escaped
+
+Enacting clause
+
+1. Section
+(1) hello
+EOS
+
+      to_xml(node.preface).should == '<preface>
+  <p>Blah blah</p>
+  <longTitle>
+    <p>a long title</p>
+  </longTitle>
+  <p>LONGTITLE escaped</p>
+  <p>Enacting clause</p>
+</preface>'
+    end
+
+    it 'should ignore a longtitle in preamble' do
+      node = parse :preamble, <<EOS
+PREAMBLE
+
+LONGTITLE a long title
+EOS
+
+      to_xml(node).should == '<preamble>
+  <p>LONGTITLE a long title</p>
+</preamble>'
+    end
+
+    it 'should ignore a longtitle in body' do
+      node = parse :body, <<EOS
+1. Section
+
+LONGTITLE a long title
+EOS
+
+      to_xml(node).should == '<body>
+  <section id="section-1">
+    <num>1.</num>
+    <heading>Section</heading>
+    <paragraph id="section-1.paragraph-0">
+      <content>
+        <p>LONGTITLE a long title</p>
+      </content>
+    </paragraph>
+  </section>
+</body>'
+    end
+  end
 end

--- a/spec/za/act_block_spec.rb
+++ b/spec/za/act_block_spec.rb
@@ -1960,20 +1960,20 @@ EOS
   end
 
   #-------------------------------------------------------------------------------
-  # clauses
+  # inline_items
 
-  context 'clauses' do
+  context 'inline_items' do
     it 'should handle a simple clause' do
-      node = parse :clauses, "simple text"
+      node = parse :inline_items, "simple text"
       node.text_value.should == "simple text"
     end
 
     it 'should handle a clause with a remark' do
-      node = parse :clauses, "simple [[remark]]. text"
+      node = parse :inline_items, "simple [[remark]]. text"
       node.text_value.should == "simple [[remark]]. text"
       node.elements[7].is_a?(Slaw::Grammars::ZA::Act::Remark).should be_true
 
-      node = parse :clauses, "simple [[remark]][[another]] text"
+      node = parse :inline_items, "simple [[remark]][[another]] text"
       node.text_value.should == "simple [[remark]][[another]] text"
       node.elements[7].is_a?(Slaw::Grammars::ZA::Act::Remark).should be_true
       node.elements[7].is_a?(Slaw::Grammars::ZA::Act::Remark).should be_true
@@ -1984,7 +1984,7 @@ EOS
   # crossheadings
 
   context 'crossheadings' do
-    it 'should handle a clauses in crossheadings' do
+    it 'should handle a inline_items in crossheadings' do
       node = parse :crossheading, "CROSSHEADING something [[remark]] [link](/foo/bar)\n"
       to_xml(node, '').should == '<hcontainer id="crossheading-0" name="crossheading">
   <heading>something <remark status="editorial">[remark]</remark> <ref href="/foo/bar">link</ref></heading>

--- a/spec/za/act_block_spec.rb
+++ b/spec/za/act_block_spec.rb
@@ -27,6 +27,10 @@ describe Slaw::ActGenerator do
     b.doc.root.to_xml(encoding: 'UTF-8')
   end
 
+  before(:each) do
+    Slaw::Grammars::ZA::Act::Crossheading.counters.clear
+  end
+
   #-------------------------------------------------------------------------------
   # General body
 
@@ -37,6 +41,8 @@ Some content before the section
 
 1. Section
 Hello there
+
+CROSSHEADING crossheading
 EOS
       to_xml(node).should == '<body>
   <paragraph id="paragraph-0">
@@ -52,6 +58,9 @@ EOS
         <p>Hello there</p>
       </content>
     </paragraph>
+    <hcontainer id="section-1.crossheading-0" name="crossheading">
+      <heading>crossheading</heading>
+    </hcontainer>
   </section>
 </body>'
     end
@@ -63,8 +72,12 @@ Some content before the section
 (a) foo
 (b) bar
 
+CROSSHEADING crossheading
+
 1. Section
 Hello there
+
+CROSSHEADING crossheading
 EOS
       to_xml(node).should == '<body>
   <paragraph id="paragraph-0">
@@ -82,6 +95,9 @@ EOS
       </blockList>
     </content>
   </paragraph>
+  <hcontainer id="crossheading-0" name="crossheading">
+    <heading>crossheading</heading>
+  </hcontainer>
   <section id="section-1">
     <num>1.</num>
     <heading>Section</heading>
@@ -90,6 +106,9 @@ EOS
         <p>Hello there</p>
       </content>
     </paragraph>
+    <hcontainer id="section-1.crossheading-0" name="crossheading">
+      <heading>crossheading</heading>
+    </hcontainer>
   </section>
 </body>'
     end
@@ -98,6 +117,8 @@ EOS
       node = parse :body, <<EOS
 \\1. ignored
 
+\\CROSSHEADING crossheading
+
 1. Section
 \\Chapter 2 ignored
 EOS
@@ -105,6 +126,7 @@ EOS
   <paragraph id="paragraph-0">
     <content>
       <p>1. ignored</p>
+      <p>CROSSHEADING crossheading</p>
     </content>
   </paragraph>
   <section id="section-1">
@@ -172,6 +194,8 @@ EOS
 Chapter 2
 The Chapter Heading
 
+CROSSHEADING crossheading
+
 Some lines at the start of the chapter.
 EOS
       node.num.should == "2"
@@ -179,6 +203,9 @@ EOS
       to_xml(node).should == '<chapter id="chapter-2">
   <num>2</num>
   <heading>The Chapter Heading</heading>
+  <hcontainer id="chapter-2.crossheading-0" name="crossheading">
+    <heading>crossheading</heading>
+  </hcontainer>
   <paragraph id="chapter-2.paragraph-0">
     <content>
       <p>Some lines at the start of the chapter.</p>
@@ -315,12 +342,18 @@ EOS
       node = parse :part, <<EOS
 pART 2
 The Part Heading
+
+CROSSHEADING crossheading
+
 1. Section
 Hello there
 EOS
       to_xml(node).should == '<part id="part-2">
   <num>2</num>
   <heading>The Part Heading</heading>
+  <hcontainer id="part-2.crossheading-0" name="crossheading">
+    <heading>crossheading</heading>
+  </hcontainer>
   <section id="section-1">
     <num>1.</num>
     <heading>Section</heading>
@@ -1944,6 +1977,18 @@ EOS
       node.text_value.should == "simple [[remark]][[another]] text"
       node.elements[7].is_a?(Slaw::Grammars::ZA::Act::Remark).should be_true
       node.elements[7].is_a?(Slaw::Grammars::ZA::Act::Remark).should be_true
+    end
+  end
+
+  #-------------------------------------------------------------------------------
+  # crossheadings
+
+  context 'crossheadings' do
+    it 'should handle a clauses in crossheadings' do
+      node = parse :crossheading, "CROSSHEADING something [[remark]] [link](/foo/bar)\n"
+      to_xml(node, '').should == '<hcontainer id="crossheading-0" name="crossheading">
+  <heading>something <remark status="editorial">[remark]</remark> <ref href="/foo/bar">link</ref></heading>
+</hcontainer>'
     end
   end
 end

--- a/spec/za/act_inline_spec.rb
+++ b/spec/za/act_inline_spec.rb
@@ -185,6 +185,17 @@ EOS
   </doc>
 </component>'
     end
+
+    it 'should handle other inline content' do
+      node = parse :block_paragraphs, <<EOS
+      Remark [[with **bold** and //italics// and [a ref](/a/b)]].
+EOS
+      to_xml(node, "").should == '<paragraph id="paragraph-0">
+  <content>
+    <p>Remark <remark status="editorial">[with <b>bold</b> and <i>italics</i> and <ref href="/a/b">a ref</ref>]</remark>.</p>
+  </content>
+</paragraph>'
+    end
   end
 
   #-------------------------------------------------------------------------------

--- a/spec/za/act_inline_spec.rb
+++ b/spec/za/act_inline_spec.rb
@@ -340,4 +340,127 @@ EOS
     end
   end
 
+  #-------------------------------------------------------------------------------
+  # italics and bold
+
+  describe 'bold' do
+    it 'should handle simple bold' do
+      node = parse :block_paragraphs, <<EOS
+      Hello **something bold** foo
+EOS
+      to_xml(node, "").should == '<paragraph id="paragraph-0">
+  <content>
+    <p>Hello <b>something bold</b> foo</p>
+  </content>
+</paragraph>'
+    end
+
+    it 'should handle complex bold' do
+      node = parse :block_paragraphs, <<EOS
+      A [**link**](/a/b) with bold
+      This is **bold with [a link](/a/b)** end
+      This is **bold //italics [a link](/a/b)//** end
+      A **[link**](/a/b)**
+      A **[link**](/a/b)
+EOS
+      to_xml(node, "").should == '<paragraph id="paragraph-0">
+  <content>
+    <p>A <ref href="/a/b"><b>link</b></ref> with bold</p>
+    <p>This is <b>bold with <ref href="/a/b">a link</ref></b> end</p>
+    <p>This is <b>bold <i>italics <ref href="/a/b">a link</ref></i></b> end</p>
+    <p>A <b>[link</b>](/a/b)**</p>
+    <p>A **<ref href="/a/b">link**</ref></p>
+  </content>
+</paragraph>'
+    end
+
+    it 'should not mistake bold' do
+      node = parse :block_paragraphs, <<EOS
+      Hello **something
+      New line**
+      **New line
+      ****
+      **
+      *
+      * * foo **
+      * * foo * *
+      ** foo * *
+EOS
+      to_xml(node, "").should == '<paragraph id="paragraph-0">
+  <content>
+    <p>Hello **something</p>
+    <p>New line**</p>
+    <p>**New line</p>
+    <p>****</p>
+    <p>**</p>
+    <p>*</p>
+    <p>* * foo **</p>
+    <p>* * foo * *</p>
+    <p>** foo * *</p>
+  </content>
+</paragraph>'
+    end
+  end
+
+  describe 'italics' do
+    it 'should handle simple italics' do
+      node = parse :block_paragraphs, <<EOS
+      Hello //something italics// foo
+EOS
+      to_xml(node, "").should == '<paragraph id="paragraph-0">
+  <content>
+    <p>Hello <i>something italics</i> foo</p>
+  </content>
+</paragraph>'
+    end
+
+    it 'should handle complex italics' do
+      node = parse :block_paragraphs, <<EOS
+      A [//link//](/a/b) with italics
+      This is //italics with [a link](/a/b)// end
+      A //italics**bold//**
+      A **bold//italics**//
+      A //[link//](/a/b)//
+      A //[link//](/a/b)
+EOS
+      to_xml(node, "").should == '<paragraph id="paragraph-0">
+  <content>
+    <p>A <ref href="/a/b"><i>link</i></ref> with italics</p>
+    <p>This is <i>italics with <ref href="/a/b">a link</ref></i> end</p>
+    <p>A //italics<b>bold//</b></p>
+    <p>A **bold<i>italics**</i></p>
+    <p>A <i>[link</i>](/a/b)//</p>
+    <p>A //<ref href="/a/b">link//</ref></p>
+  </content>
+</paragraph>'
+    end
+
+    it 'should not mistake italics' do
+      node = parse :block_paragraphs, <<EOS
+      Hello //something
+      New line//
+      //New line
+      ////
+      //
+      /
+      / / foo //
+      / / foo / /
+      // foo / /
+EOS
+      to_xml(node, "").should == '<paragraph id="paragraph-0">
+  <content>
+    <p>Hello //something</p>
+    <p>New line//</p>
+    <p>//New line</p>
+    <p>////</p>
+    <p>//</p>
+    <p>/</p>
+    <p>/ / foo //</p>
+    <p>/ / foo / /</p>
+    <p>// foo / /</p>
+  </content>
+</paragraph>'
+    end
+  end
+
 end


### PR DESCRIPTION
This pulls in a number of improvements from slaw-ke:

* Inline bold and italics
* Support for CROSSHEADING elements using an empty hcontainer until we support AKN 3.0
* Support for LONGTITLE in PREFACE
* Remarks and references support nested inline elements
* `clauses` rule renamed to `inline_elements` so as not to clash with real AKN clauses

Fixes https://github.com/laws-africa/slaw-ke/issues/1 and https://github.com/laws-africa/slaw-ke/issues/2