### PR TITLE
Don't pretty-print XML

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ You can create your own grammar by creating a gem that provides these files and 
 
 ## Changelog
 
-### 4.0.0 (?)
+### 4.0.0 (29 May 2019)
 
 * Preserve whitespace for mixed content nodes
 * Don't pretty-print XML, as this can introduce meaningful whitespace

--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ You can create your own grammar by creating a gem that provides these files and 
 
 ## Changelog
 
-### 3.5.0 (?)
+### 4.0.0 (?)
 
-* Preserver whitespace for mixed content nodes
+* Preserve whitespace for mixed content nodes
+* Don't pretty-print XML, as this can introduce meaningful whitespace
 
 ### 3.4.0 (20 May 2019)
 

--- a/bin/slaw
+++ b/bin/slaw
@@ -75,7 +75,7 @@ class SlawCLI < Thor
       exit 1
     end
 
-    puts act.to_xml(indent: 2)
+    puts act.to_xml(save_with: Nokogiri::XML::Node::SaveOptions::AS_XML)
   end
 
   desc "unparse FILE", "Unparse FILE from Akoma Ntoso XML back into text suitable for re-parsing"

--- a/lib/slaw/version.rb
+++ b/lib/slaw/version.rb
@@ -1,3 +1,3 @@
 module Slaw
-  VERSION = "3.4.0"
+  VERSION = "4.0.0"
 end


### PR DESCRIPTION
Pretty-printing introduces meaningful whitespace into some elements,
which is incorrect. For example:

```
<p>
  <remark>a remark</remark>
</p>
```

is not the same as

```
<p><remark>a remark</remark></p>
```

since `<p>` is allowed to contain whitespace