### PR TITLE
make body optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ You can create your own grammar by creating a gem that provides these files and 
 
 ## Changelog
 
+### 4.2.0 (7 Sept 2019)
+
+* BODY is allowed to be empty
+
 ### 4.1.0 (4 June 2019)
 
 * BODY marks start of body

--- a/lib/slaw/grammars/za/act.treetop
+++ b/lib/slaw/grammars/za/act.treetop
@@ -42,7 +42,7 @@ module Slaw
 
         rule body
           ('BODY' space? eol)?
-          children:(chapter / part / section / subsection / generic_container)+ <Body>
+          children:(chapter / part / section / subsection / generic_container)* <Body>
         end
 
         rule chapter

--- a/lib/slaw/version.rb
+++ b/lib/slaw/version.rb
@@ -1,3 +1,3 @@
 module Slaw
-  VERSION = "4.1.0"
+  VERSION = "4.2.0"
 end

--- a/spec/za/act_block_spec.rb
+++ b/spec/za/act_block_spec.rb
@@ -169,6 +169,31 @@ EOS
   </section>
 </body>'
     end
+
+    it 'should handle no body and a schedule' do
+      node = parse :act, <<EOS
+this is in the preface
+
+SCHEDULE
+
+some stuff
+EOS
+
+      b = ::Nokogiri::XML::Builder.new
+      b.root do |b|
+        node.to_xml(b)
+      end
+      xml = b.to_xml(encoding: 'UTF-8')
+
+      xml.should include('<body/>')
+    end
+
+    it 'should handle an empty body' do
+      node = parse :body, <<EOS
+EOS
+
+      to_xml(node).should == '<body/>'
+    end
   end
 
   #-------------------------------------------------------------------------------


### PR DESCRIPTION
This doesn't actually produce valid akoma ntoso, but it is useful when importing documents that are entirely contained in a schedule.