### PR TITLE
Always pass id prefixes to root node

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ You can create your own grammar by creating a gem that provides these files and 
 
 ## Changelog
 
+### 8.0.0 (19 Feb 2020)
+
+* Obey --id-prefix for group nodes
+* Ensure that schedules prefix their children, for those that require it (parts and chapters)
+
 ### 7.0.0 (31 Jan 2020)
 
 * Lists ids are now numbered sequentially, rather than by tree position

--- a/lib/slaw/grammars/core_nodes.rb
+++ b/lib/slaw/grammars/core_nodes.rb
@@ -1,8 +1,8 @@
 module Slaw
   module Grammars
     class GroupNode < Treetop::Runtime::SyntaxNode
-      def to_xml(b, *args)
-        children.elements.each { |e| e.to_xml(b, *args) }
+      def to_xml(b, id_prefix='')
+        children.elements.each { |e| e.to_xml(b, id_prefix) }
       end
     end
 

--- a/lib/slaw/grammars/core_nodes.rb
+++ b/lib/slaw/grammars/core_nodes.rb
@@ -7,7 +7,7 @@ module Slaw
     end
 
     class Body < Treetop::Runtime::SyntaxNode
-      def to_xml(b)
+      def to_xml(b, id_prefix='')
         b.body { |b|
           children.elements.each_with_index { |e, i| e.to_xml(b, '', i) }
         }

--- a/lib/slaw/grammars/za/act_nodes.rb
+++ b/lib/slaw/grammars/za/act_nodes.rb
@@ -137,13 +137,8 @@ module Slaw
             heading.num
           end
 
-          def to_xml(b, *args)
-            id = "part-#{num}"
-
-            # include a chapter number in the id if our parent has one
-            if parent and parent.parent.is_a?(Chapter) and parent.parent.num
-              id = "chapter-#{parent.parent.num}.#{id}"
-            end
+          def to_xml(b, id_prefix='', *args)
+            id = id_prefix + "part-#{num}"
 
             b.part(id: id) { |b|
               heading.to_xml(b)
@@ -172,13 +167,8 @@ module Slaw
             heading.num
           end
 
-          def to_xml(b, *args)
-            id = "chapter-#{num}"
-
-            # include a part number in the id if our parent has one
-            if parent and parent.parent.is_a?(Part) and parent.parent.num
-              id = "part-#{parent.parent.num}.#{id}"
-            end
+          def to_xml(b, id_prefix='', *args)
+            id = id_prefix + "chapter-#{num}"
 
             b.chapter(id: id) { |b|
               heading.to_xml(b)

--- a/lib/slaw/parse/builder.rb
+++ b/lib/slaw/parse/builder.rb
@@ -148,14 +148,7 @@ module Slaw
         builder.akomaNtoso("xmlns:xsi"=> "http://www.w3.org/2001/XMLSchema-instance", 
                            "xsi:schemaLocation" => "http://www.akomantoso.org/2.0 akomantoso20.xsd",
                            "xmlns" => NS) do |b|
-          args = [b]
-
-          # should we provide an id prefix?
-          arity = tree.method('to_xml').arity 
-          arity = arity.abs-1 if arity < 0
-          args << (fragment_id_prefix || "") if arity > 1
-
-          tree.to_xml(*args)
+          tree.to_xml(b, fragment_id_prefix || '')
         end
 
         builder.to_xml(encoding: 'UTF-8')

--- a/lib/slaw/version.rb
+++ b/lib/slaw/version.rb
@@ -1,3 +1,3 @@
 module Slaw
-  VERSION = "7.0.0"
+  VERSION = "8.0.0"
 end

--- a/spec/za/act_schedules_spec.rb
+++ b/spec/za/act_schedules_spec.rb
@@ -383,19 +383,19 @@ EOS
       <hcontainer id="schedule1" name="schedule">
         <heading>Schedule 1</heading>
         <subheading>Forms</subheading>
-        <part id="part-I">
+        <part id="schedule1.part-I">
           <num>I</num>
           <heading>Form of authentication statement</heading>
-          <paragraph id="part-I.paragraph0">
+          <paragraph id="schedule1.part-I.paragraph0">
             <content>
               <p>This printed impression has been carefully compared by me with the bill which was passed by Parliament and found by me to be a true copy of the bill.</p>
             </content>
           </paragraph>
         </part>
-        <part id="part-II">
+        <part id="schedule1.part-II">
           <num>II</num>
           <heading>Form of statement of the President’s assent.</heading>
-          <paragraph id="part-II.paragraph0">
+          <paragraph id="schedule1.part-II.paragraph0">
             <content>
               <p>I signify my assent to the bill and a whole bunch of other stuff.</p>
             </content>


### PR DESCRIPTION
This results in chapters and parts in schedules including a schedule
id prefix, which is new. With AKN 3, this should all be rationalised.

Partly fixes laws-africa/indigo#887