### PR TITLE
Improve inline (un)escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ You can create your own grammar by creating a gem that provides these files and 
 
 ## Changelog
 
+### 10.4.2 (14 April 2021)
+
+* Handle escaping inlines when unparsing.
+
 ### 10.4.1 (14 April 2021)
 
 * Handle escaping in inlines, so that forward slashes in link text are unescaped correctly, eg `[https:\/\/example.com](https://example.com)`

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You can create your own grammar by creating a gem that provides these files and 
 
 ## Changelog
 
-### 10.4.2 (14 April 2021)
+### 10.5.0 (20 April 2021)
 
 * Handle escaping inlines when unparsing.
 

--- a/lib/slaw/grammars/inlines.treetop
+++ b/lib/slaw/grammars/inlines.treetop
@@ -20,7 +20,7 @@ module Slaw
       end
 
       rule inline_item
-        remark / image / ref / bold / italics / superscript / subscript / [^\n]
+        remark / image / ref / bold / italics / superscript / subscript / '\\'? [^\n]
         <InlineItem>
       end
 

--- a/lib/slaw/grammars/inlines_nodes.rb
+++ b/lib/slaw/grammars/inlines_nodes.rb
@@ -37,8 +37,12 @@ module Slaw
 
       class InlineItem < Treetop::Runtime::SyntaxNode
         def to_xml(b, idprefix)
-          # handle escaped characters foo\/bar -> foo/bar
-          b.text(text_value.gsub(/\\(.)?/, '\1'))
+          if text_value.start_with? '\\'
+            # handle escaped characters: \a -> a
+            b.text(text_value[1..])
+          else
+            b.text(text_value)
+          end
         end
       end
 

--- a/lib/slaw/grammars/za/act_text.xsl
+++ b/lib/slaw/grammars/za/act_text.xsl
@@ -65,11 +65,11 @@
                                         </xsl:call-template>
                                       </xsl:with-param>
                                       <xsl:with-param name="value"><xsl:value-of select="'**'" /></xsl:with-param>
-                                      <xsl:with-param name="replacement"><xsl:value-of select="'\**'" /></xsl:with-param>
+                                      <xsl:with-param name="replacement"><xsl:value-of select="'\*\*'" /></xsl:with-param>
                                     </xsl:call-template>
                                   </xsl:with-param>
                                   <xsl:with-param name="value"><xsl:value-of select="'//'" /></xsl:with-param>
-                                  <xsl:with-param name="replacement"><xsl:value-of select="'\//'" /></xsl:with-param>
+                                  <xsl:with-param name="replacement"><xsl:value-of select="'\/\/'" /></xsl:with-param>
                                 </xsl:call-template>
                               </xsl:with-param>
                               <xsl:with-param name="value"><xsl:value-of select="'_^'" /></xsl:with-param>
@@ -81,7 +81,7 @@
                         </xsl:call-template>
                       </xsl:with-param>
                       <xsl:with-param name="value"><xsl:value-of select="'^^'" /></xsl:with-param>
-                      <xsl:with-param name="replacement"><xsl:value-of select="'\^^'" /></xsl:with-param>
+                      <xsl:with-param name="replacement"><xsl:value-of select="'\^\^'" /></xsl:with-param>
                   </xsl:call-template>
                 </xsl:with-param>
                 <xsl:with-param name="value"><xsl:value-of select="'!['" /></xsl:with-param>
@@ -93,11 +93,11 @@
             </xsl:call-template>
           </xsl:with-param>
           <xsl:with-param name="value"><xsl:value-of select="'[['" /></xsl:with-param>
-          <xsl:with-param name="replacement"><xsl:value-of select="'\[['" /></xsl:with-param>
+          <xsl:with-param name="replacement"><xsl:value-of select="'\[\['" /></xsl:with-param>
         </xsl:call-template>
       </xsl:with-param>
       <xsl:with-param name="value"><xsl:value-of select="']]'" /></xsl:with-param>
-      <xsl:with-param name="replacement"><xsl:value-of select="'\]]'" /></xsl:with-param>
+      <xsl:with-param name="replacement"><xsl:value-of select="'\]\]'" /></xsl:with-param>
     </xsl:call-template>
   </xsl:template>
 

--- a/lib/slaw/grammars/za/act_text.xsl
+++ b/lib/slaw/grammars/za/act_text.xsl
@@ -55,29 +55,41 @@
                             <xsl:call-template name="string-replace-all">
                               <xsl:with-param name="text">
                                 <xsl:call-template name="string-replace-all">
-                                  <xsl:with-param name="text" select="$text" />
-                                  <xsl:with-param name="value"><xsl:value-of select="'\'" /></xsl:with-param>
-                                  <xsl:with-param name="replacement"><xsl:value-of select="'\\'" /></xsl:with-param>
+                                  <xsl:with-param name="text">
+                                    <xsl:call-template name="string-replace-all">
+                                      <xsl:with-param name="text">
+                                        <xsl:call-template name="string-replace-all">
+                                          <xsl:with-param name="text" select="$text" />
+                                          <xsl:with-param name="value"><xsl:value-of select="'\'" /></xsl:with-param>
+                                          <xsl:with-param name="replacement"><xsl:value-of select="'\\'" /></xsl:with-param>
+                                        </xsl:call-template>
+                                      </xsl:with-param>
+                                      <xsl:with-param name="value"><xsl:value-of select="'**'" /></xsl:with-param>
+                                      <xsl:with-param name="replacement"><xsl:value-of select="'\**'" /></xsl:with-param>
+                                    </xsl:call-template>
+                                  </xsl:with-param>
+                                  <xsl:with-param name="value"><xsl:value-of select="'//'" /></xsl:with-param>
+                                  <xsl:with-param name="replacement"><xsl:value-of select="'\//'" /></xsl:with-param>
                                 </xsl:call-template>
                               </xsl:with-param>
-                              <xsl:with-param name="value"><xsl:value-of select="'**'" /></xsl:with-param>
-                              <xsl:with-param name="replacement"><xsl:value-of select="'\**'" /></xsl:with-param>
+                              <xsl:with-param name="value"><xsl:value-of select="'_^'" /></xsl:with-param>
+                              <xsl:with-param name="replacement"><xsl:value-of select="'\_^'" /></xsl:with-param>
                             </xsl:call-template>
                           </xsl:with-param>
-                          <xsl:with-param name="value"><xsl:value-of select="'//'" /></xsl:with-param>
-                          <xsl:with-param name="replacement"><xsl:value-of select="'\//'" /></xsl:with-param>
+                          <xsl:with-param name="value"><xsl:value-of select="'^_'" /></xsl:with-param>
+                          <xsl:with-param name="replacement"><xsl:value-of select="'\^_'" /></xsl:with-param>
                         </xsl:call-template>
                       </xsl:with-param>
-                      <xsl:with-param name="value"><xsl:value-of select="'_^'" /></xsl:with-param>
-                      <xsl:with-param name="replacement"><xsl:value-of select="'\_^'" /></xsl:with-param>
-                    </xsl:call-template>
-                  </xsl:with-param>
-                  <xsl:with-param name="value"><xsl:value-of select="'^^'" /></xsl:with-param>
-                  <xsl:with-param name="replacement"><xsl:value-of select="'\^^'" /></xsl:with-param>
-                </xsl:call-template>
+                      <xsl:with-param name="value"><xsl:value-of select="'^^'" /></xsl:with-param>
+                      <xsl:with-param name="replacement"><xsl:value-of select="'\^^'" /></xsl:with-param>
+                  </xsl:call-template>
+                </xsl:with-param>
+                <xsl:with-param name="value"><xsl:value-of select="'!['" /></xsl:with-param>
+                <xsl:with-param name="replacement"><xsl:value-of select="'\!['" /></xsl:with-param>
+              </xsl:call-template>
               </xsl:with-param>
-              <xsl:with-param name="value"><xsl:value-of select="'!['" /></xsl:with-param>
-              <xsl:with-param name="replacement"><xsl:value-of select="'\!['" /></xsl:with-param>
+              <xsl:with-param name="value"><xsl:value-of select="']('" /></xsl:with-param>
+              <xsl:with-param name="replacement"><xsl:value-of select="'\]('" /></xsl:with-param>
             </xsl:call-template>
           </xsl:with-param>
           <xsl:with-param name="value"><xsl:value-of select="'[['" /></xsl:with-param>

--- a/lib/slaw/version.rb
+++ b/lib/slaw/version.rb
@@ -1,3 +1,3 @@
 module Slaw
-  VERSION = "10.4.2"
+  VERSION = "10.5.0"
 end

--- a/lib/slaw/version.rb
+++ b/lib/slaw/version.rb
@@ -1,3 +1,3 @@
 module Slaw
-  VERSION = "10.4.1"
+  VERSION = "10.4.2"
 end

--- a/spec/fixtures/roundtrip-escapes.txt
+++ b/spec/fixtures/roundtrip-escapes.txt
@@ -1,0 +1,20 @@
+BODY
+
+1. Section that tests escapes
+
+text \\ with a single slash
+
+some **inlines \/\/ [with \/\/ slashes](#foo)**
+
+inlines that \*\* should \/\/ be \[\[ escaped \![ and \]\]
+
+refs [https:\/\/example.com with ] and and \]( and **nested \*\* stars \*\***](#foo)
+
+nested ** stars \*\* in bold \*\***
+
+nested // slashes \/\/ in italics \/\///
+
+nested ** stars in // italics \*\* // and bold **
+
+super ^^with \^\^ hats \^\^^^ and sub _^\_^ with \^_ end tokens \^_^_
+

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -146,13 +146,13 @@ XML
 
 text \\\\ with a single slash
 
-some **inlines \// [with \// slashes](#foo)**
+some **inlines \/\/ [with \/\/ slashes](#foo)**
 
-inlines that \** should \// be \[[ escaped \![ and \]]
+inlines that \*\* should \/\/ be \[\[ escaped \![ and \]\]
 
-refs [https:\//example.com with ] and \]( and **nested \****](#foo)
+refs [https:\/\/example.com with ] and \]( and **nested \*\***](#foo)
 
-super ^^with \^^^^ and sub _^\_^ with \^_^_
+super ^^with \^\^^^ and sub _^\_^ with \^_^_
 
 '
     end

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -68,6 +68,9 @@ Some content.
             <p>(a) ignored</p>
             <p>(2a) ignored</p>
             <p>{| ignored</p>
+            <p>text \\ with slashes</p>
+            <p>some <b>inlines // <ref href="#foo">with // slashes</ref></b></p>
+            <p>inlines that ** should // be [[ escaped ![ and ]]</p>
           </content>
         </paragraph>
 XML
@@ -78,45 +81,51 @@ XML
 
 1. Section
 
-\Chapter 2 ignored
+\\Chapter 2 ignored
 
 Chapters
 
-\Part 2 ignored
+\\Part 2 ignored
 
 participation
 
-\Schedule 2 ignored
+\\Schedule 2 ignored
 
 Schedules
 
-\HEADING x
+\\HEADING x
 
-\SUBHEADING x
+\\SUBHEADING x
 
 BODY not escaped
 
-\BODY
+\\BODY
 
 PREAMBLE not escaped
 
-\PREAMBLE
+\\PREAMBLE
 
 PREFACE not escaped
 
-\PREFACE
+\\PREFACE
 
-\2. ignored
+\\2. ignored
 
-\2.1 ignored
+\\2.1 ignored
 
-\(2) ignored
+\\(2) ignored
 
-\(a) ignored
+\\(a) ignored
 
-\(2a) ignored
+\\(2a) ignored
 
-\{| ignored
+\\{| ignored
+
+text \\\\ with slashes
+
+some **inlines \\// [with \\// slashes](#foo)**
+
+inlines that \\** should \\// be \\[[ escaped \\![ and \\]]
 
 '
     end
@@ -148,7 +157,7 @@ XML
 
 1. Section
 
-\(2) A special meeting [[ foo ]]:
+\\(2) A special meeting [[ foo ]]:
 
 (a) the chairperson so directs; or
 

--- a/spec/za/act_block_spec.rb
+++ b/spec/za/act_block_spec.rb
@@ -117,16 +117,19 @@ EOS
     it 'should handle escaped content' do
       node = parse :body, <<EOS
 \\1. ignored
+foo \\\\bar
 
 \\CROSSHEADING cross\\heading
 
 1. Sec\\tion
 \\Chapter 2 ignored
+Some text with a \\\\real backslash
 EOS
       to_xml(node).should == '<body>
   <hcontainer eId="hcontainer_1" name="hcontainer">
     <content>
       <p>1. ignored</p>
+      <p>foo \\bar</p>
       <p>CROSSHEADING crossheading</p>
     </content>
   </hcontainer>
@@ -136,6 +139,7 @@ EOS
     <hcontainer eId="sec_1__hcontainer_1" name="hcontainer">
       <content>
         <p>Chapter 2 ignored</p>
+        <p>Some text with a \\real backslash</p>
       </content>
     </hcontainer>
   </section>


### PR DESCRIPTION
This adds escaping for special inlines, and ensures they are escaped when unparsing. Fixes #55 